### PR TITLE
Update and rename DataConnectorsStorageAccounts _PolicyAssignment.jso…

### DIFF
--- a/built-in-policies/policyDefinitions/Storage/Storage_DeployDiagnosticLog_Deploy_LogAnalytics.json
+++ b/built-in-policies/policyDefinitions/Storage/Storage_DeployDiagnosticLog_Deploy_LogAnalytics.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "displayName": "Configure diagnostic settings for storage accounts to Log Analytics workspace",
+    "displayName": "Deploy Diagnostic Settings for Storage accounts to Log Analytics workspace",
     "description": "Deploys the diagnostic settings for storage accounts to stream resource logs to a Log Analytics workspace when any storage account which is missing this diagnostic settings is created or updated.",
     "policyType": "BuiltIn",
     "mode": "Indexed",


### PR DESCRIPTION
…n to Storage_DeployDiagnosticLog_Deploy_LogAnalytics.json

Updated to keep policy name consistent with other Azure Polices for Diagnostic Settings as per https://github.com/Azure/azure-policy/tree/master/built-in-policies/policyDefinitions/Monitoring